### PR TITLE
Lösungsvorschlag #1

### DIFF
--- a/code/web/Babesk/Menu/Menu.php
+++ b/code/web/Babesk/Menu/Menu.php
@@ -40,6 +40,7 @@ class Menu extends Babesk {
 		$meal = array();
 		$orders_existing = true;
 		$meal_problems = false;
+		$mealHistory = array();
 
 		try {
 			$orders = $orderManager->getAllOrdersOfUser($_SESSION['uid'], strtotime(date('Y-m-d')));


### PR DESCRIPTION
Lösungsvorschlag für #1.
Definiert die Variable als Array.
Meiner Meinung müsste Zeile 77-82 ohne diese Definition gar nicht gehen.

define $mealHistory as array
